### PR TITLE
[Core] Fix travis cache when cache is clear

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ container:
 		--build-arg TRAVIS=$(TRAVIS) \
 		--tag=$(PROGRAM) ./
 
-run: update
+run:
 	@docker run $(SETTING) \
 		python bot build
 

--- a/bot/__main__.py
+++ b/bot/__main__.py
@@ -53,6 +53,7 @@ runner.set("build", [
     "validator.connection",
     "validator.content",
     "environment.prepare_git",
+    "environment.prepare_mirror",
     "environment.prepare_pacman",
     "environment.clean_mirror",
     "repository.synchronize",

--- a/bot/environment.py
+++ b/bot/environment.py
@@ -6,7 +6,7 @@ import sys
 import textwrap
 import subprocess
 
-from utils.process import output, git_remote_path
+from utils.process import output, git_remote_path, strict_execute
 
 
 class Environment(object):
@@ -33,7 +33,18 @@ class Environment(object):
         print("  [ ✓ ] " + text("content.environment.up.to.date"))
 
     def prepare_mirror(self):
-        self._execute("chmod 777 " + app.mirror)
+        sources = output("git ls-files " + app.mirror + " | awk -F / '{print $2}'").split("\n")
+
+        if len(os.listdir(app.mirror)) != len(sources):
+            return
+
+        print(text("content.environment.prepare.mirror"))
+
+        strict_execute(f"""
+        scp -i {app.base}/deploy_key -P {config.ssh.port} \
+            {config.ssh.user}@{config.ssh.host}:{config.ssh.path}/* \
+            {app.mirror}/
+        """)
 
     def prepare_git(self):
         self._execute(

--- a/bot/text/content.yml
+++ b/bot/text/content.yml
@@ -94,5 +94,9 @@ repository.validate.build: |-
 environment.pull.repository: |-
   Updating repository bot:
 
+environment.prepare.mirror: |-
+  Pull server files:
+
 environment.up.to.date: |-
   up to date
+


### PR DESCRIPTION
Cache archives are currently set to expire after 28 days for open source projects with Travis-CI and the bot need to build all the packages. To fix it, the bot pull remote files.